### PR TITLE
Add null to `Maybe a` schemas

### DIFF
--- a/src/Data/OpenApi/Internal/Schema.hs
+++ b/src/Data/OpenApi/Internal/Schema.hs
@@ -630,7 +630,7 @@ instance ToSchema a => ToSchema (Maybe a) where
           { _schemaAnyOf = Just [Inline aSchema, Inline mempty { _schemaType = Just OpenApiNull }]
           }
 
-    return $ NamedSchema mName aSchemaWithNull
+    pure $ NamedSchema mName aSchemaWithNull
 
 instance (ToSchema a, ToSchema b) => ToSchema (Either a b) where
   -- To match Aeson instance

--- a/src/Data/OpenApi/Internal/Schema.hs
+++ b/src/Data/OpenApi/Internal/Schema.hs
@@ -623,7 +623,14 @@ instance ToSchema Float       where declareNamedSchema = plain . paramSchemaToSc
 instance (Typeable (Fixed a), HasResolution a) => ToSchema (Fixed a) where declareNamedSchema = plain . paramSchemaToSchema
 
 instance ToSchema a => ToSchema (Maybe a) where
-  declareNamedSchema _ = declareNamedSchema (Proxy :: Proxy a)
+  declareNamedSchema _ = do
+    NamedSchema mName aSchema <- declareNamedSchema (Proxy :: Proxy a)
+    
+    let aSchemaWithNull = mempty
+          { _schemaOneOf = Just [Inline aSchema, Inline mempty { _schemaType = Just OpenApiNull }]
+          }
+
+    return $ NamedSchema mName aSchemaWithNull
 
 instance (ToSchema a, ToSchema b) => ToSchema (Either a b) where
   -- To match Aeson instance

--- a/src/Data/OpenApi/Internal/Schema.hs
+++ b/src/Data/OpenApi/Internal/Schema.hs
@@ -627,7 +627,7 @@ instance ToSchema a => ToSchema (Maybe a) where
     NamedSchema mName aSchema <- declareNamedSchema (Proxy :: Proxy a)
     
     let aSchemaWithNull = mempty
-          { _schemaOneOf = Just [Inline aSchema, Inline mempty { _schemaType = Just OpenApiNull }]
+          { _schemaAnyOf = Just [Inline aSchema, Inline mempty { _schemaType = Just OpenApiNull }]
           }
 
     return $ NamedSchema mName aSchemaWithNull


### PR DESCRIPTION
+ Generate a schema for `a`
+ Generate a schema with the `null` type
+ Combine both schemas with a `oneOf` to emulate `Maybe a`
+ Follows behaviour of other `Maybe` instances, e.g., `ToJSON`

Upstream PR: https://github.com/biocad/openapi3/pull/103