### PR TITLE
Use prefixItems for tuples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ cabal.sandbox.config
 *.aux
 *.hp
 .stack-work/
+stack.yaml.lock

--- a/openapi3.cabal
+++ b/openapi3.cabal
@@ -88,7 +88,7 @@ library
     , hashable                  >=1.2.7.0  && <1.5
     , http-media                >=0.8.0.0  && <0.9
     , insert-ordered-containers >=0.2.3    && <0.3
-    , lens                      >=4.16.1   && <5.3
+    , lens                      >=4.16.1   && <5.4
     , optics-core               >=0.2      && <0.5
     , optics-th                 >=0.2      && <0.5
     , scientific                >=0.3.6.2  && <0.4

--- a/openapi3.cabal
+++ b/openapi3.cabal
@@ -83,7 +83,7 @@ library
     , aeson                     >=1.4.2.0  && <1.6 || >=2.0.1.0 && < 2.3
     , aeson-pretty              >=0.8.7    && <0.9
     -- cookie 0.4.3 is needed by GHC 7.8 due to time>=1.4 constraint
-    , cookie                    >=0.4.3    && <0.5
+    , cookie                    >=0.4.3    && <0.6
     , generics-sop              >=0.5.1.0  && <0.6
     , hashable                  >=1.2.7.0  && <1.5
     , http-media                >=0.8.0.0  && <0.9

--- a/openapi3.cabal
+++ b/openapi3.cabal
@@ -95,7 +95,7 @@ library
     , unordered-containers      >=0.2.9.0  && <0.3
     , uuid-types                >=1.0.3    && <1.1
     , vector                    >=0.12.0.1 && <0.14
-    , QuickCheck                >=2.10.1   && <2.15
+    , QuickCheck                >=2.10.1   && <2.16
 
   default-language:    Haskell2010
 

--- a/src/Data/OpenApi.hs
+++ b/src/Data/OpenApi.hs
@@ -30,7 +30,6 @@ module Data.OpenApi (
 
   -- * Re-exports
   module Data.OpenApi.Lens,
-  module Data.OpenApi.Optics,
   module Data.OpenApi.Operation,
   module Data.OpenApi.ParamSchema,
   module Data.OpenApi.Schema,

--- a/src/Data/OpenApi.hs
+++ b/src/Data/OpenApi.hs
@@ -75,6 +75,7 @@ module Data.OpenApi (
   Schema(..),
   NamedSchema(..),
   OpenApiItems(..),
+  OpenApiPrefixItems(..),
   Xml(..),
   Pattern,
   AdditionalProperties(..),

--- a/src/Data/OpenApi/Declare.hs
+++ b/src/Data/OpenApi/Declare.hs
@@ -52,7 +52,7 @@ instance (Applicative m, Monad m, Monoid d) => Applicative (DeclareT d m) where
     return (mappend d' d'', f x)
 
 instance (Applicative m, Monad m, Monoid d) => Monad (DeclareT d m) where
-  return x = DeclareT (\_ -> pure (mempty, x))
+  return = pure
   DeclareT dx >>= f = DeclareT $ \d -> do
     ~(d',  x) <- dx d
     ~(d'', y) <- runDeclareT (f x) (mappend d d')

--- a/src/Data/OpenApi/Internal.hs
+++ b/src/Data/OpenApi/Internal.hs
@@ -14,6 +14,8 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
 module Data.OpenApi.Internal where
 
 import Prelude ()
@@ -335,7 +337,9 @@ instance Data MediaType where
 
   dataTypeOf _ = mediaTypeData
 
+mediaTypeConstr :: Constr
 mediaTypeConstr = mkConstr mediaTypeData "MediaType" [] Prefix
+mediaTypeData :: DataType
 mediaTypeData = mkDataType "MediaType" [mediaTypeConstr]
 
 instance Hashable MediaType where
@@ -1006,12 +1010,12 @@ deriveGeneric ''OpenApiSpecVersion
 -- =======================================================================
 
 instance Semigroup OpenApiSpecVersion where
-  (<>) (OpenApiSpecVersion a) (OpenApiSpecVersion b) = OpenApiSpecVersion $ max a b 
-  
+  (<>) (OpenApiSpecVersion a) (OpenApiSpecVersion b) = OpenApiSpecVersion $ max a b
+
 instance Monoid OpenApiSpecVersion where
   mempty = OpenApiSpecVersion (makeVersion [3,0,0])
   mappend = (<>)
-  
+
 instance Semigroup OpenApi where
   (<>) = genericMappend
 instance Monoid OpenApi where
@@ -1282,7 +1286,7 @@ instance FromJSON OAuth2AuthorizationCodeFlow where
 -- Manual ToJSON instances
 -- =======================================================================
 
-instance ToJSON OpenApiSpecVersion where 
+instance ToJSON OpenApiSpecVersion where
   toJSON (OpenApiSpecVersion v)= toJSON . showVersion $ v
 
 instance ToJSON MediaType where
@@ -1456,15 +1460,15 @@ instance FromJSON OpenApiSpecVersion where
   parseJSON = withText "OpenApiSpecVersion" $ \str ->
             let validatedVersion :: Either String Version
                 validatedVersion = do
-                  parsedVersion <- readVersion str 
+                  parsedVersion <- readVersion str
                   unless ((parsedVersion >= lowerOpenApiSpecVersion) && (parsedVersion <= upperOpenApiSpecVersion)) $
                      Left ("The provided version " <> showVersion parsedVersion <> " is out of the allowed range >=" <> showVersion lowerOpenApiSpecVersion <> " && <=" <> showVersion upperOpenApiSpecVersion)
                   return parsedVersion
-             in 
+             in
               either fail (return . OpenApiSpecVersion) validatedVersion
     where
     readVersion :: Text -> Either String Version
-    readVersion v = case readP_to_S parseVersion (Text.unpack v) of 
+    readVersion v = case readP_to_S parseVersion (Text.unpack v) of
       [] -> Left $ "Failed to parse as a version string " <> Text.unpack v
       solutions -> Right (fst . last $ solutions)
 
@@ -1649,7 +1653,7 @@ instance HasSwaggerAesonOptions Encoding where
 instance HasSwaggerAesonOptions Link where
   swaggerAesonOptions _ = mkSwaggerAesonOptions "link"
 
-instance AesonDefaultValue Version where 
+instance AesonDefaultValue Version where
   defaultValue = Just (makeVersion [3,0,0])
 instance AesonDefaultValue OpenApiSpecVersion
 instance AesonDefaultValue Server

--- a/src/Data/OpenApi/Internal.hs
+++ b/src/Data/OpenApi/Internal.hs
@@ -1373,7 +1373,7 @@ instance ToJSON OpenApiItems where
     , "maxItems" .= (0 :: Int)
     , "example" .= Array mempty
     ]
-  toJSON (OpenApiItemsArray  x) = object [ "items" .= x ]
+  toJSON (OpenApiItemsArray  x) = object [ "prefixItems" .= x ]
 
 instance ToJSON Components where
   toJSON = sopSwaggerGenericToJSON

--- a/src/Data/OpenApi/Internal/AesonUtils.hs
+++ b/src/Data/OpenApi/Internal/AesonUtils.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE ExplicitForAll #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableSuperClasses #-}
 module Data.OpenApi.Internal.AesonUtils (
     -- * Generic functions

--- a/src/Data/OpenApi/Internal/ParamSchema.hs
+++ b/src/Data/OpenApi/Internal/ParamSchema.hs
@@ -19,6 +19,7 @@ module Data.OpenApi.Internal.ParamSchema where
 
 import Control.Lens
 import Data.Aeson (ToJSON (..))
+import Data.Kind
 import Data.Proxy
 import GHC.Generics
 
@@ -163,7 +164,7 @@ instance ToParamSchema Word64 where
 --     "minimum": -128,
 --     "type": "integer"
 -- }
-toParamSchemaBoundedIntegral :: forall a t. (Bounded a, Integral a) => Proxy a -> Schema
+toParamSchemaBoundedIntegral :: forall a. (Bounded a, Integral a) => Proxy a -> Schema
 toParamSchemaBoundedIntegral _ = mempty
   & type_ ?~ OpenApiInteger
   & minimum_ ?~ fromInteger (toInteger (minBound :: a))
@@ -310,10 +311,10 @@ instance ToParamSchema UUID where
 --     ],
 --     "type": "string"
 -- }
-genericToParamSchema :: forall a t. (Generic a, GToParamSchema (Rep a)) => SchemaOptions -> Proxy a -> Schema
+genericToParamSchema :: forall a. (Generic a, GToParamSchema (Rep a)) => SchemaOptions -> Proxy a -> Schema
 genericToParamSchema opts _ = gtoParamSchema opts (Proxy :: Proxy (Rep a)) mempty
 
-class GToParamSchema (f :: * -> *) where
+class GToParamSchema (f :: Type -> Type) where
   gtoParamSchema :: SchemaOptions -> Proxy f -> Schema -> Schema
 
 instance GToParamSchema f => GToParamSchema (D1 d f) where
@@ -331,7 +332,7 @@ instance ToParamSchema c => GToParamSchema (K1 i c) where
 instance (GEnumParamSchema f, GEnumParamSchema g) => GToParamSchema (f :+: g) where
   gtoParamSchema opts _ = genumParamSchema opts (Proxy :: Proxy (f :+: g))
 
-class GEnumParamSchema (f :: * -> *) where
+class GEnumParamSchema (f :: Type -> Type) where
   genumParamSchema :: SchemaOptions -> Proxy f -> Schema -> Schema
 
 instance (GEnumParamSchema f, GEnumParamSchema g) => GEnumParamSchema (f :+: g) where

--- a/src/Data/OpenApi/Internal/Schema.hs
+++ b/src/Data/OpenApi/Internal/Schema.hs
@@ -346,7 +346,7 @@ inlineNonRecursiveSchemas defs = inlineSchemasWhen nonRecursive defs
 --         2,
 --         3
 --     ],
---     "items": {
+--     "prefixItems": {
 --         "type": "number"
 --     },
 --     "type": "array"
@@ -358,7 +358,7 @@ inlineNonRecursiveSchemas defs = inlineSchemasWhen nonRecursive defs
 --         "Jack",
 --         25
 --     ],
---     "items": [
+--     "prefixItems": [
 --         {
 --             "type": "string"
 --         },
@@ -407,6 +407,7 @@ sketchSchema = sketch . toJSON
       & items ?~ case ischema of
           Just s -> OpenApiItemsObject (Inline s)
           _      -> OpenApiItemsArray (map Inline ys)
+      & prefixItems ?~ OpenApiPrefixItemsArray (map Inline ys)
       where
         ys = map go (V.toList xs)
         allSame = and ((zipWith (==)) ys (tail ys))
@@ -573,6 +574,7 @@ sketchStrictSchema = go . toJSON
       & maxItems    ?~ fromIntegral sz
       & minItems    ?~ fromIntegral sz
       & items       ?~ OpenApiItemsArray (map (Inline . go) (V.toList xs))
+      & prefixItems ?~ OpenApiPrefixItemsArray (map (Inline . go) (V.toList xs))
       & uniqueItems ?~ allUnique
       & enum_       ?~ [js]
       where
@@ -991,6 +993,10 @@ appendItem :: Referenced Schema -> Maybe OpenApiItems -> Maybe OpenApiItems
 appendItem x Nothing = Just (OpenApiItemsArray [x])
 appendItem x (Just (OpenApiItemsArray xs)) = Just (OpenApiItemsArray (xs ++ [x]))
 appendItem _ _ = error "GToSchema.appendItem: cannot append to OpenApiItemsObject"
+
+appendPrefixItem :: Referenced Schema -> Maybe OpenApiPrefixItems -> Maybe OpenApiPrefixItems
+appendPrefixItem x Nothing = Just (OpenApiPrefixItemsArray [x])
+appendPrefixItem x (Just (OpenApiPrefixItemsArray xs)) = Just (OpenApiPrefixItemsArray (xs ++ [x]))
 
 withFieldSchema :: forall proxy s f. (Selector s, GToSchema f) =>
   SchemaOptions -> proxy s f -> Bool -> Schema -> Declare (Definitions Schema) Schema

--- a/src/Data/OpenApi/Internal/TypeShape.hs
+++ b/src/Data/OpenApi/Internal/TypeShape.hs
@@ -3,9 +3,11 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
 
 module Data.OpenApi.Internal.TypeShape where
 
+import Data.Kind
 import Data.Proxy
 import GHC.Generics
 import GHC.TypeLits
@@ -46,7 +48,7 @@ type family GenericHasSimpleShape t (f :: Symbol) (s :: TypeShape) :: Constraint
       )
 
 -- | Infer a 'TypeShape' for a generic representation of a type.
-type family GenericShape (g :: * -> *) :: TypeShape
+type family GenericShape (g :: Type -> Type) :: TypeShape
 
 type instance GenericShape (f :*: g)        = ProdCombine  (GenericShape f) (GenericShape g)
 type instance GenericShape (f :+: g)        = SumCombine   (GenericShape f) (GenericShape g)

--- a/src/Data/OpenApi/Lens.hs
+++ b/src/Data/OpenApi/Lens.hs
@@ -118,6 +118,12 @@ instance
 instance
   {-# OVERLAPPABLE #-}
   HasSchema s Schema
+  => HasPrefixItems s (Maybe OpenApiPrefixItems) where
+  prefixItems = schema.prefixItems
+
+instance
+  {-# OVERLAPPABLE #-}
+  HasSchema s Schema
   => HasMaximum s (Maybe Scientific) where
   maximum_ = schema.maximum_
 

--- a/src/Data/OpenApi/Optics.hs
+++ b/src/Data/OpenApi/Optics.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 -- |

--- a/src/Data/OpenApi/Optics.hs
+++ b/src/Data/OpenApi/Optics.hs
@@ -176,6 +176,20 @@ instance
   labelOptic = unto (\x -> OpenApiItemsObject x)
   {-# INLINE labelOptic #-}
 
+-- OpenApiPrefixItems prisms
+
+instance
+  ( a ~ [Referenced Schema]
+  , b ~ [Referenced Schema]
+  ) => LabelOptic "_OpenApiPrefixItemsArray"
+         A_Review
+         OpenApiPrefixItems
+         OpenApiPrefixItems
+         a
+         b where
+  labelOptic = unto (\x -> OpenApiPrefixItemsArray x)
+  {-# INLINE labelOptic #-}
+
 -- =============================================================
 -- More helpful instances for easier access to schema properties
 
@@ -236,10 +250,10 @@ instance
 -- #prefixItems
 
 instance
-  ( a ~ Maybe OpenApiItems
-  , b ~ Maybe OpenApiItems
+  ( a ~ Maybe OpenApiPrefixItems
+  , b ~ Maybe OpenApiPrefixItems
   ) => LabelOptic "prefixItems" A_Lens NamedSchema NamedSchema a b where
-  labelOptic = #schema % #items
+  labelOptic = #schema % #prefixItems
   {-# INLINE labelOptic #-}
 
 -- #maximum

--- a/src/Data/OpenApi/Optics.hs
+++ b/src/Data/OpenApi/Optics.hs
@@ -232,6 +232,15 @@ instance
   ) => LabelOptic "items" A_Lens NamedSchema NamedSchema a b where
   labelOptic = #schema % #items
   {-# INLINE labelOptic #-}
+  
+-- #prefixItems
+
+instance
+  ( a ~ Maybe OpenApiItems
+  , b ~ Maybe OpenApiItems
+  ) => LabelOptic "prefixItems" A_Lens NamedSchema NamedSchema a b where
+  labelOptic = #schema % #items
+  {-# INLINE labelOptic #-}
 
 -- #maximum
 

--- a/src/Data/OpenApi/Schema/Generator.hs
+++ b/src/Data/OpenApi/Schema/Generator.hs
@@ -34,6 +34,8 @@ schemaGen _ schema
     | Just cases <- schema  ^. enum_  = elements cases
 schemaGen defns schema
     | Just variants <- schema ^. oneOf = schemaGen defns =<< elements (dereference defns <$> variants)
+schemaGen defns schema
+    | Just variants <- schema ^. anyOf = schemaGen defns =<< elements (dereference defns <$> variants)
 schemaGen defns schema =
     case schema ^. type_ of
       Nothing ->

--- a/src/Data/OpenApi/Schema/Generator.hs
+++ b/src/Data/OpenApi/Schema/Generator.hs
@@ -72,6 +72,11 @@ schemaGen defns schema =
               OpenApiItemsArray refs ->
                   let itemGens = schemaGen defns . dereference defns <$> refs
                   in fmap (Array . V.fromList) $ sequence itemGens
+        | Just prefixItems <- schema ^. prefixItems -> do
+            case prefixItems of
+              OpenApiPrefixItemsArray refs ->
+                let itemGens = schemaGen defns . dereference defns <$> refs
+                in fmap (Array . V.fromList) $ sequence itemGens
       Just OpenApiString -> do
         size <- getSize
         let minLength' = fromMaybe 0 $ fromInteger <$> schema ^. minLength

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,9 +1,5 @@
-resolver: lts-16.31
+resolver: lts-21.24
 packages:
 - '.'
-extra-deps:
-- optics-core-0.3
-- optics-th-0.3
-- optics-extra-0.3
-- indexed-profunctors-0.1
-- insert-ordered-containers-0.2.3.1
+ghc-options:
+  $locals: -Wall -Wno-unused-imports -Wno-dodgy-imports -Wno-name-shadowing

--- a/test/Data/OpenApi/CommonTestTypes.hs
+++ b/test/Data/OpenApi/CommonTestTypes.hs
@@ -205,7 +205,14 @@ personSchemaJSON = [aesonQQ|
     {
       "name":   { "type": "string"  },
       "phone":  { "type": "integer" },
-      "email":  { "type": "string"  }
+      "email":
+        {
+          "anyOf" :
+            [
+              { "type" : "null" },
+              { "type": "string" }
+            ]
+        }
     },
   "required": ["name", "phone"]
 }
@@ -867,7 +874,14 @@ singleMaybeFieldSchemaJSON = [aesonQQ|
   "type": "object",
   "properties":
     {
-      "singleMaybeField": { "type": "string" }
+      "singleMaybeField":
+        {
+          "anyOf" :
+            [
+              { "type" : "null" },
+              { "type": "string" }
+            ]
+        }
     }
 }
 |]

--- a/test/Data/OpenApi/CommonTestTypes.hs
+++ b/test/Data/OpenApi/CommonTestTypes.hs
@@ -482,7 +482,7 @@ ispairSchemaJSON :: Value
 ispairSchemaJSON = [aesonQQ|
 {
   "type": "array",
-  "items":
+  "prefixItems":
     [
       { "type": "integer" },
       { "type": "string"  }

--- a/test/Data/OpenApi/Schema/GeneratorSpec.hs
+++ b/test/Data/OpenApi/Schema/GeneratorSpec.hs
@@ -68,7 +68,7 @@ spec = do
     prop "T.Text" $ shouldValidate (Proxy :: Proxy T.Text)
     prop "TL.Text" $ shouldValidate (Proxy :: Proxy TL.Text)
     prop "[String]" $ shouldValidate (Proxy :: Proxy [String])
-    -- prop "(Maybe [Int])" $ shouldValidate (Proxy :: Proxy (Maybe [Int]))
+    prop "(Maybe [Int])" $ shouldValidate (Proxy :: Proxy (Maybe [Int]))
     prop "(IntMap String)" $ shouldValidate (Proxy :: Proxy (IntMap String))
     prop "(Set Bool)" $ shouldValidate (Proxy :: Proxy (Set Bool))
     prop "(NonEmpty Bool)" $ shouldValidate (Proxy :: Proxy (NonEmpty Bool))


### PR DESCRIPTION
+ From OpenApi 3.1
+ Preserves order for tuples
  + e.g., when generating typescript from generated openapi specs
    + (a, b) becomes [a, b] instead of [a || b, a || b]